### PR TITLE
Removed spacy dependency

### DIFF
--- a/Parser.py
+++ b/Parser.py
@@ -1,6 +1,5 @@
 import codecs
 import numpy as np
-from spacy.en import English
 
 def read_email(fname):
     """Read email as unicode."""


### PR DESCRIPTION
On new version of spacy, `English` can only be called via spacy.lang.en instead of spacy.en. Moreover, it looks like Parser.py does not need it to work --> It can be removed